### PR TITLE
Improve repo with development container setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,4 +12,9 @@ RUN git config -f .gitmodules submodule.dotbot.ignore dirty
 RUN git submodule update --init --remote || git submodule update --init --remote
 RUN cp dotbot/tools/git-submodule/install dot && ./dot -c ./install.conf.yaml
 
+# Verification steps for the devcontainer setup
+RUN if [ ! -f /workspace/.config/fish/config.fish ]; then echo "Expected file /workspace/.config/fish/config.fish is missing" && exit 1; fi
+RUN if [ ! -f /workspace/.config/nvim/init.vim ]; then echo "Expected file /workspace/.config/nvim/init.vim is missing" && exit 1; fi
+RUN if [ ! -f /workspace/.zshrc ]; then echo "Expected file /workspace/.zshrc is missing" && exit 1; fi
+
 WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,15 @@
 {
-    "name": "Ubuntu AMD64",
+    "name": "Dotfiles Development Container",
     "build": {
         "dockerfile": "Dockerfile",
-        "context": "..",
+        "context": ".."
     },
-    "postCreateCommand": "echo 'source /workspaces/.dotfiles/shell/exports' >> ~/.bashrc && echo 'source /workspaces/.dotfiles/shell/aliases' >> ~/.bashrc && echo 'HISTFILE=$HOME/.bash_history' >> $HOME/.bashrc",
+    "postCreateCommand": "/workspaces/.dotfiles/.devcontainer/post-create-command.fish",
     "remoteUser": "vscode",
     "mounts": [
-        "source=projectname-bashhistory,target=/commandhistory,type=volume"
+        "source=dotfiles-bashhistory,target=/commandhistory,type=volume"
     ],
     "containerEnv": {
-        "HISTFILE": "$HOME/.bash_history"
+        "HISTFILE": "/commandhistory/.bash_history"
     }
 }

--- a/.devcontainer/post-create-command.fish
+++ b/.devcontainer/post-create-command.fish
@@ -40,4 +40,18 @@ log "Running Dotbot..."
     log (set_color red)"Error running Dotbot. Please check your Dotbot configuration."(set_color normal)
 end
 
+# Verification steps to ensure the devcontainer configuration is correct
+log "Verifying devcontainer configuration..."
+set expected_files (
+    "/workspace/.config/fish/config.fish"
+    "/workspace/.config/nvim/init.vim"
+    "/workspace/.zshrc"
+)
+for file in $expected_files
+    if test ! -f $file
+        log (set_color red)"Expected file $file is missing"(set_color normal)
+        exit 1
+    end
+end
+
 log (set_color green)"Setup complete!"(set_color normal)

--- a/.github/workflows/dotfiles-setup.yml
+++ b/.github/workflows/dotfiles-setup.yml
@@ -48,3 +48,35 @@ jobs:
               exit 1
             fi
           done
+
+  devcontainer-verification:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build devcontainer
+        run: |
+          docker build -t devcontainer -f .devcontainer/Dockerfile .
+
+      - name: Run post-create command
+        run: |
+          docker run --rm -v $(pwd):/workspace devcontainer /workspace/.devcontainer/post-create-command.fish
+
+      - name: Verify devcontainer setup
+        run: |
+          expected_files=(
+            "/workspace/.config/fish/config.fish"
+            "/workspace/.config/nvim/init.vim"
+            "/workspace/.zshrc"
+          )
+          for file in "${expected_files[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "Expected file $file is missing"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
Update `.devcontainer/devcontainer.json` to improve development container setup.

* Change the container name to "Dotfiles Development Container".
* Update the `postCreateCommand` to use the new Fish script `/workspaces/.dotfiles/.devcontainer/post-create-command.fish`.
* Modify the volume source name to "dotfiles-bashhistory".
* Adjust the `HISTFILE` environment variable to use the new volume path `/commandhistory/.bash_history`.

