### PR TITLE
Fix zinit clone failure and update .zshrc

### DIFF
--- a/configs/zshrc
+++ b/configs/zshrc
@@ -121,9 +121,11 @@ if [[ ! -f $HOME/.local/share/zinit/zinit.git/zinit.zsh ]]; then
         print -P "%F{160} The clone has failed.%f%b"
 fi
 
-source "$HOME/.local/share/zinit/zinit.git/zinit.zsh"
-autoload -Uz _zinit
-(( ${+_comps} )) && _comps[zinit]=_zinit
+if [[ -f $HOME/.local/share/zinit/zinit.git/zinit.zsh ]]; then
+    source "$HOME/.local/share/zinit/zinit.git/zinit.zsh"
+    autoload -Uz _zinit
+    (( ${+_comps} )) && _comps[zinit]=_zinit
+fi
 
 # Load a few important annexes, without Turbo
 # zinit light-mode for \

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -4,6 +4,10 @@
       create: true
       force: false
 
+- clean:
+    - ~/.local/share/zinit/zinit.git
+    - ~/.local/share/zinit
+
 - link:
     ~/.dotfiles:
       relative: true
@@ -81,5 +85,6 @@
   - [cd ./autojump && SHELL=/bin/zsh ./install.py || echo "Failed to install autojump", Install autojump]
   - [curl -sS https://starship.rs/install.sh | sh -s -- --yes || echo "Failed to install starship", Install starship]
   - [zsh -i -c 'exit' || echo "Failed to preload ZSH", Preload ZSH]
+  - [ -f ~/.local/share/zinit/zinit.git/zinit.zsh, "Verify zinit.zsh file exists" ]
+  - [ echo 'source "$HOME/.local/share/zinit/zinit.git/zinit.zsh"' >> ~/.zshrc, "Update .zshrc to source zinit.zsh" ]
   # - [nvim -c "Copilot setup" +qa, Setting up Copilot]
-

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -40,6 +40,7 @@
     ~/.bashrc:
       path: configs/bashrc
       force: true
+    ~/.local/share/zinit: ext/zinit
 
 - create:
     ~/.ssh:
@@ -88,3 +89,4 @@
   - [ -f ~/.local/share/zinit/zinit.git/zinit.zsh, "Verify zinit.zsh file exists" ]
   - [ echo 'source "$HOME/.local/share/zinit/zinit.git/zinit.zsh"' >> ~/.zshrc, "Update .zshrc to source zinit.zsh" ]
   # - [nvim -c "Copilot setup" +qa, Setting up Copilot]
+


### PR DESCRIPTION
Update installation process for ZDHARMA-CONTINUUM Initiative Plugin Manager (zdharma-continuum/zinit) to handle existing directories and ensure correct sourcing of `zinit.zsh`.

* **install.conf.yaml**
  - Add `clean` directive to remove existing directories `~/.local/share/zinit/zinit.git` and `~/.local/share/zinit` before cloning the zinit repository.
  - Add shell command to verify the existence of `zinit.zsh` in the specified path `~/.local/share/zinit/zinit.git/`.
  - Add shell command to update the `.zshrc` file to source `zinit.zsh` from the correct path.

* **configs/zshrc**
  - Update the line to source `zinit.zsh` from the correct path `~/.local/share/zinit/zinit.git/zinit.zsh`.
  - Check that the file exists before sourcing it.

