### PR TITLE
Implement new dotbot config

### DIFF
--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -4,82 +4,46 @@
       create: true
       force: false
 
-- link:
-    ~/.dotfiles:
-      relative: true
-      path: "."
-    ~/.config/cargo/config.toml: configs/config/cargo/config.toml
-    ~/.config/fish/config.fish: configs/config/fish/config.fish
-    ~/.config/fish/fish_variables: configs/config/fish/fish_variables
-    ~/.config/gh-copilot/config.yml: configs/config/gh-copilot/config.yml
-    ~/.config/gh/config.yml: configs/config/gh/config.yml
-    ~/.config/nvim/init.vim: configs/config/nvim/init.vim
-    ~/.config/starship.toml: configs/config/starship.toml
-    ~/.gemrc: configs/gemrc
-    ~/.gitconfig: configs/gitconfig
-    ~/.gitignore: configs/gitignore
-    ~/.hushlogin: configs/hushlogin
-    ~/.irbrc: configs/irbrc
-    ~/.rspec: configs/rspec
-    ~/.rubocop.yml: configs/rubocop.yml
-    ~/.rustfmt.toml: configs/rustfmt.toml
-    ~/.ssh/config:
-      path: configs/ssh/config
-      perm: 0644
-    ~/.ssh/known_hosts:
-      path: configs/ssh/known_hosts
-      force: true
-    ~/.config/karabiner/karabiner.json: configs/config/karabiner/karabiner.json
-    ~/.zshrc:
-      path: configs/zshrc
-      force: true
-    ~/.bashrc:
-      path: configs/bashrc
-      force: true
-
 - create:
     ~/.ssh:
       perm: 0755
 
-- ifhostname:
-    hostname: macbook.local
-    met:
-      - shell:
-        - [cargo binstall -y git-ai || echo "Failed to install git-ai", Install git-ai]
-    unmet: {}
-- ifhostname:
-    hostname: homeassistant.local
-    unmet:
-      - shell:
-        - [curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash, Install cargo-binstall]
-    met:
-      shell:
-        - [apk add --update cargo, Install cargo]
-        - [cargo binstall -y --targets x86_64-unknown-linux-musl git-ai, Install git-ai]
-      link:
-        ~/.local:
-          path: /share/ssh/local
-          force: true
-        ~/.cargo:
-          path: /share/ssh/cargo
-          force: true
-        ~/.rustup:
-          path: /share/ssh/rustup
-          force: true
-        create:
-          - /share/ssh/rustup
-          - /share/ssh/local
-          - /share/ssh/cargo
+- link:
+    ~/.dotfiles:
+      relative: true
+      path: .
+    ~/:
+      prefix: .
+      glob: true
+      path: configs/*
+      exclude: [configs/config]
+      force: true
+    ~/.config:
+      glob: true
+      path: configs/config/**
+
+- link:
+    init.sh:
+      if: test $(hostname) = homeassistant.local
+      path: init/homeassistant.sh
+
+- link:
+    init.sh:
+      if: test $(hostname) = macos.local
+      path: init/macos.sh
 
 - shell:
-  - [git pull, Pull submodules]
-  - [git submodule sync --quiet --recursive, Sync submodules, Sync submodules]
-  - [git submodule update --init --recursive, Install submodules, Update submodules]
-  - [curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim || echo "Failed to install vim-plug", Install vim-plug]
-  - [nvim +PlugInstall! +qa || echo "Failed to load plugin manager into neovim", Load plugin manager into neovim]
-  - [cd ./autojump && chmod +x ./install.py || echo "Failed to make install script executable", Make install script executable]
-  - [cd ./autojump && SHELL=/bin/zsh ./install.py || echo "Failed to install autojump", Install autojump]
-  - [curl -sS https://starship.rs/install.sh | sh -s -- --yes || echo "Failed to install starship", Install starship]
-  - [zsh -i -c 'exit' || echo "Failed to preload ZSH", Preload ZSH]
-  # - [nvim -c "Copilot setup" +qa, Setting up Copilot]
-
+  - command: ./init.sh
+    description: Execute init script for current host
+  - command: curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim || echo Failed to install vim-plug
+    description: Install vim-plug
+  - command: nvim +PlugInstall! +qa || echo Failed to load plugin manager into neovim
+    description: Load plugin manager into neovim
+  - command: cd ./autojump && chmod +x ./install.py || echo Failed to make install script executable
+    description: Make install script executable
+  - command: cd ./autojump && SHELL=/bin/zsh ./install.py || echo Failed to install autojump
+    description: Install autojump
+  - command: curl -sS https://starship.rs/install.sh | sh -s -- --yes || echo Failed to install starship
+    description: Install starship
+  - command: zsh -i -c 'exit' || echo Failed to preload ZSH
+    description: Preload ZSH


### PR DESCRIPTION
Implement the new dotbot configuration in `install.conf.yaml`.

* **Defaults:**
  - Add `relink: true`, `create: true`, and `force: false` options.

* **Create:**
  - Add `~/.ssh` with `perm: 0755`.

* **Link:**
  - Add `~/.dotfiles` with `relative: true` and `path: .`.
  - Add `~/` with `prefix: .`, `glob: true`, `path: configs/*`, `exclude: [configs/config]`, and `force: true`.
  - Add `~/.config` with `glob: true` and `path: configs/config/**`.
  - Add `init.sh` with `if: test $(hostname) = homeassistant.local` and `path: init/homeassistant.sh`.
  - Add `init.sh` with `if: test $(hostname) = macos.local` and `path: init/macos.sh`.

* **Shell:**
  - Add command `./init.sh` with description "Execute init script for current host".
  - Add command `curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim || echo Failed to install vim-plug` with description "Install vim-plug".
  - Add command `nvim +PlugInstall! +qa || echo Failed to load plugin manager into neovim` with description "Load plugin manager into neovim".
  - Add command `cd ./autojump && chmod +x ./install.py || echo Failed to make install script executable` with description "Make install script executable".
  - Add command `cd ./autojump && SHELL=/bin/zsh ./install.py || echo Failed to install autojump` with description "Install autojump".
  - Add command `curl -sS https://starship.rs/install.sh | sh -s -- --yes || echo Failed to install starship` with description "Install starship".
  - Add command `zsh -i -c 'exit' || echo Failed to preload ZSH` with description "Preload ZSH".

